### PR TITLE
Use different env var name

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -4,7 +4,7 @@
 
 # Option 1: Read secrets from the environment
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-DATABASE_URL=$DATABASE_URL
+DATABASE_URL=$PROD_DATABASE_URL
 SECRET=$SECRET
 
 # Option 2: Read secrets via a command


### PR DESCRIPTION
If "`DATABASE_URL`" is defined in dev, we _could_ end up connecting to it.

(Probably should limit access in Neon)